### PR TITLE
Switched input for bed and extruder temp to match ui

### DIFF
--- a/calibrate_beta.cfg
+++ b/calibrate_beta.cfg
@@ -179,8 +179,8 @@ gcode:
 description: Calibrate the printer flow or pressure advance
 gcode:
     {% set TYPE = params.TYPE|default("-PA-or-FLOW-")|string|lower %}
-    {% set BED_TEMP = params.BED_TEMP|default(printer["gcode_macro _USER_VARIABLES_CALIBRATE"].print_default_bed_temp)|float %}
     {% set EXTRUDER_TEMP = params.EXTRUDER_TEMP|default(printer["gcode_macro _USER_VARIABLES_CALIBRATE"].print_default_extruder_temp)|float %}
+    {% set BED_TEMP = params.BED_TEMP|default(printer["gcode_macro _USER_VARIABLES_CALIBRATE"].print_default_bed_temp)|float %}
 
     {% if TYPE=="flow" %}
         FLOW_MULTIPLIER_CALIBRATION EXTRUDER_TEMP={EXTRUDER_TEMP} BED_TEMP={BED_TEMP}


### PR DESCRIPTION
The inputs for bed and extruder temps are switched in comparison to the normal ui (ae. mainsailos) which is "confusing" (at least myself :P)

I've switched them to match the normal ui.