### PR TITLE
Fix calculation of last PA band

### DIFF
--- a/calibrate.cfg
+++ b/calibrate.cfg
@@ -289,7 +289,7 @@ gcode:
     {action_respond_info("Dieser Vorgang kann mit normalen Mitteln nicht unterbrochen werden. Druecken Sie die Taste \"Not-Aus\", sobald der Druck offensichtlich zu hohe PA-Werte aufweist.")}
     {action_respond_info("")}
     {action_respond_info("PA des ersten Bands: %.4f" % pa_start)}
-    {action_respond_info("PA des letzten Bands: %.4f" % (num_bands * pa_increment))}
+    {action_respond_info("PA des letzten Bands: %.4f" % (pa_start + ((num_bands - 1) * pa_increment)))}
     {action_respond_info("PA Anhebung pro Band: %.4f" % pa_increment)}
     {action_respond_info("Anzahl Baender: %d" % num_bands)}
     {action_respond_info("")}


### PR DESCRIPTION
Hi,
erstmal vielen Dank für die super Arbeit an diesem Macro 👍 

Beim Testen ist mir aufgefallen dass das letzte Band bei der PA Kalibrierung falsch berechnet wird.
![grafik](https://user-images.githubusercontent.com/12832850/209688107-5051e32c-686a-4b44-8b91-f85fe0d4914a.png)

PA des letzten Bandes ist in diesem Fall 0,05.

![grafik](https://user-images.githubusercontent.com/12832850/209688326-cd26c654-b8a4-4cf0-929b-f5bf2e01377f.png)

Macht weiter so 👍 Freue mich schon auf die nächsten Versionen


